### PR TITLE
Remove redundant callback in Connection.php

### DIFF
--- a/src/Picqer/Financials/Exact/Connection.php
+++ b/src/Picqer/Financials/Exact/Connection.php
@@ -190,11 +190,6 @@ class Connection
             $this->redirectForAuthorization();
         }
 
-        if (is_callable($this->refreshAccessTokenCallback)) {
-            // check if the token has been refreshed by some other means
-            call_user_func($this->refreshAccessTokenCallback, $this);
-        }
-
         // If access token is not set or token has expired, acquire new token
         if (empty($this->accessToken) || $this->tokenHasExpired()) {
             $this->acquireAccessToken();
@@ -646,7 +641,7 @@ class Connection
     }
 
     /**
-     * @param $callback
+     * @param callable $callback
      */
     public function setRefreshAccessTokenCallback($callback)
     {


### PR DESCRIPTION
Removed the redundant refreshAccessTokenCallback in connect() method in Connection.php
Thanks :)!
See https://github.com/picqer/exact-php-client/pull/449#issuecomment-742474167